### PR TITLE
Fix error during adding event with empty `configs.data`

### DIFF
--- a/scheduler.js
+++ b/scheduler.js
@@ -1143,7 +1143,7 @@ var Scheduler = (function (element, userConfigs) {
     else {
       events.$id = configs.data.length;
       events.start = new Date(events.start);
-      if (configs.data[i].end) {
+      if (configs.data[i] && configs.data[i].end) {
         events.end = new Date(events.end);
       }
       else {


### PR DESCRIPTION
If `configs.data[i]` is undefined, accessing `configs.data[i].end` will prompt an _Uncaught TypeError_ error.

Adding this will avoid the error by only accessing `configs.data[i].end` when `configs.data[i]` is defined.

Encountered this when trying to run [this code](https://github.com/jerry54604/scheduler.js/issues/13#issuecomment-278173735) at #13.